### PR TITLE
Fix transaction for Yii 2.0.40 in Oci8PDO.php

### DIFF
--- a/Oci8PDO.php
+++ b/Oci8PDO.php
@@ -164,6 +164,16 @@
         {
             return $this->_isTransaction;
         }
+        
+        /**
+         * Returns true if the current process is in a transaction
+         *
+         * @return bool
+         */
+        public function inTransaction()
+        {
+            return $this->_isTransaction;
+        }
 
         /**
          * Commits all statements issued during a transaction and ends the transaction


### PR DESCRIPTION
Yii v2.0.40 calls $transaction->db->pdo->inTransaction() directly and causes an exception:

PDO::inTransaction(): SQLSTATE[00000]: No error: PDO constructor was not called